### PR TITLE
Rewrite GDPSUtils public API

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,3 @@
+CompileFlags:
+  Add:
+    - -Wall

--- a/include/GDPSUtils.hpp
+++ b/include/GDPSUtils.hpp
@@ -8,15 +8,6 @@
 #define MY_MOD_ID "km7dev.gdps-switcher"
 
 namespace GDPSUtils {
-    /**
-    * @brief Creates a new server with a specified name, url, and optionally a save directory.
-    * 
-    * @param name The name of the server.
-    * @param url The URL of the server.
-    * @param saveDir Save directory for the server, don't pass for default.
-    * @param modRequired Whether the server requires the mod to work. if true, the GDPS will not load if the mod is not loaded.
-    * @return The id of the server.
-    */
 
     struct CreateServerArgs {
         std::string name;
@@ -41,7 +32,7 @@ namespace GDPSUtils {
     };
     inline geode::Result<> updateServer(UpdateServerArgs args) GEODE_EVENT_EXPORT(&updateServer, (args));
     /**
-    * @brief Retrieves a list of all available servers.
+    * @brief Retrieves a list of all servers added by the specified mod.
     * 
     * @return A map the available servers.
     */
@@ -52,21 +43,8 @@ namespace GDPSUtils {
     * @return The current server.
     */
     inline geode::Result<GDPSTypes::Server> getCurrentServer() GEODE_EVENT_EXPORT(&getCurrentServer, ());
-    /**
-    * @brief Sets the current server.
-    *
-    * @param id The id of the server to set as current.
-    * @return True if the server was set successfully.
-    */
-
 
     inline geode::Result<bool> deleteServer(int id, geode::Mod* mod = geode::Mod::get()) GEODE_EVENT_EXPORT(&deleteServer, (id, mod));
-    /**
-    * @brief Change the current server to the one with the specified id. Requires restart.
-    *
-    * @param id The id of the server to set as current.
-    * @return True if the server was set successfully.
-    */
 };
 
 #endif

--- a/include/GDPSUtils.hpp
+++ b/include/GDPSUtils.hpp
@@ -2,6 +2,7 @@
 #define GDPSUTILS_HPP
 
 #include "Types.hpp"
+#include <matjson.hpp>
 #include <string>
 #include <Geode/loader/Dispatch.hpp>
 #define MY_MOD_ID "km7dev.gdps-switcher"
@@ -13,9 +14,32 @@ namespace GDPSUtils {
     * @param name The name of the server.
     * @param url The URL of the server.
     * @param saveDir Save directory for the server, don't pass for default.
+    * @param modRequired Whether the server requires the mod to work. if true, the GDPS will not load if the mod is not loaded.
     * @return The id of the server.
     */
-    inline geode::Result<int> createServer(std::string name, std::string url, bool modRequired = true, std::string saveDir = "", geode::Mod* mod = geode::Mod::get()) GEODE_EVENT_EXPORT(&createServer, (name, url, modRequired, saveDir, mod));
+
+    struct CreateServerArgs {
+        std::string name;
+        std::string url;
+        bool modRequired = false;
+        std::string saveDir = "";
+        matjson::Value customData;
+        std::string motd = "";
+        geode::Mod* mod = geode::Mod::get();
+    };
+    inline geode::Result<int> createServer(CreateServerArgs args) GEODE_EVENT_EXPORT(&createServer, (args));
+    
+    struct UpdateServerArgs {
+        int id;
+        std::string name;
+        std::string url;
+        bool modRequired = false;
+        std::string saveDir = "";
+        matjson::Value customData;
+        std::string motd = "";
+        geode::Mod* mod = geode::Mod::get();
+    };
+    inline geode::Result<> updateServer(UpdateServerArgs args) GEODE_EVENT_EXPORT(&updateServer, (args));
     /**
     * @brief Retrieves a list of all available servers.
     * 

--- a/include/GDPSUtils.hpp
+++ b/include/GDPSUtils.hpp
@@ -1,4 +1,3 @@
-#if 0
 #ifndef GDPSUTILS_HPP
 #define GDPSUTILS_HPP
 
@@ -16,13 +15,13 @@ namespace GDPSUtils {
     * @param saveDir Save directory for the server, don't pass for default.
     * @return The id of the server.
     */
-    inline geode::Result<int> createServer(std::string name, std::string url, std::string saveDir = "") GEODE_EVENT_EXPORT(&createServer, (name, url, saveDir));
+    inline geode::Result<int> createServer(std::string name, std::string url, bool modRequired = true, std::string saveDir = "", geode::Mod* mod = geode::Mod::get()) GEODE_EVENT_EXPORT(&createServer, (name, url, modRequired, saveDir, mod));
     /**
     * @brief Retrieves a list of all available servers.
     * 
     * @return A map the available servers.
     */
-    inline geode::Result<std::map<int, GDPSTypes::Server>> getServers() GEODE_EVENT_EXPORT(&getServers, ());
+    inline geode::Result<std::map<int, GDPSTypes::Server>> getModServers(geode::Mod* mod = geode::Mod::get()) GEODE_EVENT_EXPORT(&getModServers, (mod));
     /**
     * @brief Retrieves the current server.
     *
@@ -35,47 +34,15 @@ namespace GDPSUtils {
     * @param id The id of the server to set as current.
     * @return True if the server was set successfully.
     */
-    inline geode::Result<bool> setCurrentServer(int id) GEODE_EVENT_EXPORT(&setCurrentServer, (id));
-    /**
-    * @brief Finds a server by its url and optionally its save directory.
-    *
-    * @param url The URL of the server to find.
-    * @param saveDir The save directory of the server to find, don't pass to find any server with the same URL.
-    * @return The server if found.
-    */
-    inline geode::Result<GDPSTypes::Server> findServer(std::string url, std::string saveDir = "") GEODE_EVENT_EXPORT(&findServer, (url, saveDir));
-    /**
-    * @brief Deletes a server.
-    *
-    * @param id The id of the server to delete.
-    * @return True if the server was deleted successfully.
-    */
-    inline geode::Result<bool> deleteServer(int id) GEODE_EVENT_EXPORT(&deleteServer, (id));
+
+
+    inline geode::Result<bool> deleteServer(int id, geode::Mod* mod = geode::Mod::get()) GEODE_EVENT_EXPORT(&deleteServer, (id, mod));
     /**
     * @brief Change the current server to the one with the specified id. Requires restart.
     *
     * @param id The id of the server to set as current.
     * @return True if the server was set successfully.
     */
-    inline geode::Result<bool> switchServer(int id) GEODE_EVENT_EXPORT(&switchServer, (id));
-    /**
-    * @brief Retrieves information about a server by its id.
-    *
-    * @param id The id of the server to retrieve information about.
-    * @return The server information if found.
-    */
-    inline geode::Result<GDPSTypes::Server> getServerInfo(int id) GEODE_EVENT_EXPORT(&getServerInfo, (id));
-    /**
-    * @brief Sets information for a server. Allows selective updates for name, URL, or save directory.
-    *
-    * @param id The id of the server to update.
-    * @param name Optional new name of the server. Pass an empty string to keep the current name.
-    * @param url Optional new URL of the server. Pass an empty string to keep the current URL.
-    * @param saveDir Optional new save directory of the server. Pass an empty string to keep the current save directory.
-    * @return True if the server information was updated successfully.
-    */
-    inline geode::Result<bool> setServerInfo(int id, std::string name = "", std::string url = "", std::string saveDir = "") GEODE_EVENT_EXPORT(&setServerInfo, (id, name, url, saveDir));
 };
 
-#endif
 #endif

--- a/include/Types.hpp
+++ b/include/Types.hpp
@@ -137,8 +137,12 @@ namespace GDPSTypes {
         std::string name;
         std::string url;
         std::string saveDir;
-        std::string addedByModId;
-        bool modRequired = false;
+        struct ModInfo {
+            std::string modId;
+            bool modRequired = false;
+            matjson::Value customData;
+        };
+        std::optional<ModInfo> modInfo;
 
         // Many issues and stuff
         // std::string modPolicy = "blacklist";
@@ -151,7 +155,11 @@ namespace GDPSTypes {
         bool iconIsSprite = false;
         std::string icon;
 
-        Server(const int id, std::string name, std::string url, std::string saveDir, std::string addedByModId, bool modRequired) : id(id), name(std::move(name)), url(std::move(url)), saveDir(std::move(saveDir)), addedByModId(addedByModId), modRequired(modRequired) {}
+        Server(const int id, std::string name, std::string url, std::string saveDir, std::string addedByModId, bool modRequired) : id(id), name(std::move(name)), url(std::move(url)), saveDir(std::move(saveDir)) {
+            if (!addedByModId.empty()) {
+                modInfo = ModInfo{std::move(addedByModId), modRequired, {}};
+            }
+        }
         Server() = default;
         Server(const Server&) = default;
         Server(Server&&) = default;
@@ -191,14 +199,18 @@ struct matjson::Serialize<GDPSTypes::Server>
 {
     static geode::Result<GDPSTypes::Server> fromJson(matjson::Value const &value)
     {
+        auto modId = value["addedByModId"].asString().unwrapOrDefault();
+        auto modRequired = value["modRequired"].asBool().unwrapOrDefault();
         GDPSTypes::Server server(
             value["id"].asInt().unwrapOr(-1),
             value["name"].asString().unwrapOr("Failed to load name."),
             value["url"].asString().unwrapOr("Failed to load url."),
             value["saveDir"].asString().unwrapOr(value["url"].asString().unwrapOr("Failed to load save directory.")),
-            value["addedByModId"].asString().unwrapOrDefault(),
-            value["modRequired"].asBool().unwrapOrDefault()
+            modId, modRequired
         );
+        if (server.modInfo.has_value()) {
+            server.modInfo->customData = value["customData"];
+        }
         return geode::Ok(server);
     }
 
@@ -209,9 +221,12 @@ struct matjson::Serialize<GDPSTypes::Server>
             {"name", value.name},
             {"url", value.url},
             {"saveDir", value.saveDir},
-            {"addedByModId", value.addedByModId},
-            {"modRequired", value.modRequired},
         });
+        if (value.modInfo.has_value()) {
+            obj["addedByModId"] = value.modInfo->modId;
+            obj["modRequired"] = value.modInfo->modRequired;
+            obj["customData"] = value.modInfo->customData;
+        }
         return obj;
     }
 };

--- a/include/Types.hpp
+++ b/include/Types.hpp
@@ -14,6 +14,7 @@
 
 #include <ranges>
 #include <utility>
+#include <string>
 
 namespace GDPSTypes {
 
@@ -136,6 +137,8 @@ namespace GDPSTypes {
         std::string name;
         std::string url;
         std::string saveDir;
+        std::string addedByModId;
+        bool modRequired = false;
 
         // Many issues and stuff
         // std::string modPolicy = "blacklist";
@@ -148,7 +151,7 @@ namespace GDPSTypes {
         bool iconIsSprite = false;
         std::string icon;
 
-        Server(const int id, std::string name, std::string url, std::string saveDir) : id(id), name(std::move(name)), url(std::move(url)), saveDir(std::move(saveDir)) {}
+        Server(const int id, std::string name, std::string url, std::string saveDir, std::string addedByModId, bool modRequired) : id(id), name(std::move(name)), url(std::move(url)), saveDir(std::move(saveDir)), addedByModId(addedByModId), modRequired(modRequired) {}
         Server() = default;
         Server(const Server&) = default;
         Server(Server&&) = default;
@@ -192,11 +195,10 @@ struct matjson::Serialize<GDPSTypes::Server>
             value["id"].asInt().unwrapOr(-1),
             value["name"].asString().unwrapOr("Failed to load name."),
             value["url"].asString().unwrapOr("Failed to load url."),
-            value["saveDir"].asString().unwrapOr(value["url"].asString().unwrapOr("Failed to load save directory."))
+            value["saveDir"].asString().unwrapOr(value["url"].asString().unwrapOr("Failed to load save directory.")),
+            value["addedByModId"].asString().unwrapOrDefault(),
+            value["modRequired"].asBool().unwrapOrDefault()
         );
-        // server.dependencies = value["mods"]["dependencies"].as<std::map<std::string, std::string>>().unwrapOr(std::map<std::string, std::string>());
-        // server.modPolicy = value["mods"]["policy"].asString().unwrapOr("whitelist");
-        // server.modList = value["mods"]["modList"].as<std::vector<std::string>>().unwrapOr(std::vector<std::string>());
         return geode::Ok(server);
     }
 
@@ -207,11 +209,8 @@ struct matjson::Serialize<GDPSTypes::Server>
             {"name", value.name},
             {"url", value.url},
             {"saveDir", value.saveDir},
-            // {"mods", matjson::makeObject({
-            //     {"dependencies", value.dependencies},
-            //     {"policy", value.modPolicy},
-            //     {"modList", value.modList}
-            // })}
+            {"addedByModId", value.addedByModId},
+            {"modRequired", value.modRequired},
         });
         return obj;
     }

--- a/include/Types.hpp
+++ b/include/Types.hpp
@@ -155,10 +155,7 @@ namespace GDPSTypes {
         bool iconIsSprite = false;
         std::string icon;
 
-        Server(const int id, std::string name, std::string url, std::string saveDir, std::string addedByModId, bool modRequired) : id(id), name(std::move(name)), url(std::move(url)), saveDir(std::move(saveDir)) {
-            if (!addedByModId.empty()) {
-                modInfo = ModInfo{std::move(addedByModId), modRequired, {}};
-            }
+        Server(const int id, std::string name, std::string url, std::string saveDir, std::optional<ModInfo> modInfo = std::nullopt) : id(id), name(std::move(name)), url(std::move(url)), saveDir(std::move(saveDir)), modInfo(modInfo) {
         }
         Server() = default;
         Server(const Server&) = default;
@@ -199,18 +196,22 @@ struct matjson::Serialize<GDPSTypes::Server>
 {
     static geode::Result<GDPSTypes::Server> fromJson(matjson::Value const &value)
     {
-        auto modId = value["addedByModId"].asString().unwrapOrDefault();
-        auto modRequired = value["modRequired"].asBool().unwrapOrDefault();
+        std::optional<GDPSTypes::Server::ModInfo> modInfo;
+        if(value.contains("modInfo")) {
+            modInfo = GDPSTypes::Server::ModInfo{
+                value["modInfo"]["modId"].asString().unwrapOr(""),
+                value["modInfo"]["modRequired"].asBool().unwrapOr(false),
+                value["modInfo"]["customData"]
+            };
+        }
         GDPSTypes::Server server(
             value["id"].asInt().unwrapOr(-1),
             value["name"].asString().unwrapOr("Failed to load name."),
             value["url"].asString().unwrapOr("Failed to load url."),
             value["saveDir"].asString().unwrapOr(value["url"].asString().unwrapOr("Failed to load save directory.")),
-            modId, modRequired
+            modInfo
         );
-        if (server.modInfo.has_value()) {
-            server.modInfo->customData = value["customData"];
-        }
+
         return geode::Ok(server);
     }
 
@@ -223,9 +224,11 @@ struct matjson::Serialize<GDPSTypes::Server>
             {"saveDir", value.saveDir},
         });
         if (value.modInfo.has_value()) {
-            obj["addedByModId"] = value.modInfo->modId;
-            obj["modRequired"] = value.modInfo->modRequired;
-            obj["customData"] = value.modInfo->customData;
+            obj["modInfo"] = matjson::makeObject({
+                {"modId", value.modInfo->modId},
+                {"modRequired", value.modInfo->modRequired},
+                {"customData", value.modInfo->customData}
+            });
         }
         return obj;
     }

--- a/mod.json
+++ b/mod.json
@@ -1,12 +1,12 @@
 {
-	"geode": "5.3.0",
+	"geode": "5.8.2",
 	"gd": {
 		"win": "2.2081",
 		"android": "2.2081",
 		"mac": "2.2081",
 		"ios": "2.2081"
 	},
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"id": "km7dev.gdps-switcher",
 	"name": "GDPS Switcher",
 	"developers": ["km7dev", "Alphii"],

--- a/src/apis/GDPSUtils.cpp
+++ b/src/apis/GDPSUtils.cpp
@@ -1,15 +1,20 @@
-#if 0
 
 // MUST be defined before including the header.
-#define GEODE_DEFINE_EVENT_EXPORTS
-#include <GDPSUtils.hpp>
-#include "../ui/ServerListLayer.hpp"
 #include "../utils/GDPSMain.hpp"
-#include <km7dev.server_api/include/ServerAPIEvents.hpp>
-#include "../utils/ServerInfoManager.hpp"
+
+// Dispatch.hpp is #pragma once, so we must manually redefine
+// the macros to the "define" (export) variants here.
+#define GEODE_DEFINE_EVENT_EXPORTS
+#undef GEODE_EVENT_EXPORT
+#define GEODE_EVENT_EXPORT(fnPtr, callArgs) \
+    GEODE_EVENT_EXPORT_DEFINE(fnPtr, callArgs, GEODE_EVENT_EXPORT_ID_FOR(#fnPtr, #callArgs))
+#undef GEODE_EVENT_EXPORT_NORES
+#define GEODE_EVENT_EXPORT_NORES(fnPtr, callArgs) \
+    GEODE_EVENT_EXPORT(fnPtr, callArgs)
+#include <GDPSUtils.hpp>
 using namespace geode::prelude;
 
-Result<int> GDPSUtils::createServer(std::string name, std::string url, std::string saveDir) {
+Result<int> GDPSUtils::createServer(std::string name, std::string url, bool modRequired, std::string saveDir, geode::Mod* mod) {
     int id = 0;
     for (auto &[serverId, server] : GDPSMain::get()->m_servers) {
         if (serverId < 0) continue;
@@ -24,14 +29,18 @@ Result<int> GDPSUtils::createServer(std::string name, std::string url, std::stri
     server.url = url;
     server.id = id;
     server.saveDir = saveDir.empty() ? fmt::format("{}", id) : saveDir;
-    GDPSMain::get()->m_servers[id] = std::make_shared<GDPSTypes::Server>(std::move(server));
+    server.addedByModId = mod->getID();
+    server.modRequired = modRequired;
+    auto res = GDPSMain::get()->registerServer(std::make_shared<GDPSTypes::Server>(std::move(server)));
+    if (!res) return Err(res.unwrapErr());
     GDPSMain::get()->save();
     return Ok(id);
 }
 
-Result<std::map<int, GDPSTypes::Server>> GDPSUtils::getServers() {
+Result<std::map<int, GDPSTypes::Server>> GDPSUtils::getModServers(geode::Mod* mod) {
     std::map<int, GDPSTypes::Server> ret;
     for (auto [id, server] : GDPSMain::get()->m_servers) {
+        if (server->addedByModId != mod->getID()) continue;
         ret[id] = *server.get();
     }
     return Ok(ret);
@@ -44,55 +53,18 @@ Result<GDPSTypes::Server> GDPSUtils::getCurrentServer() {
     return Ok(*res.unwrap().get());
 }
 
-Result<bool> GDPSUtils::setCurrentServer(int id) {
+// This should be a Result<void> but too late to change it.
+Result<bool> GDPSUtils::deleteServer(int id, geode::Mod* mod) {
     auto it = GDPSMain::get()->m_servers.find(id);
     if (it == GDPSMain::get()->m_servers.end()) {
         return Err("Server not found");
     }
-    GDPSMain::get()->m_currentServer = id;
-    return Ok(true);
-}
-
-Result<GDPSTypes::Server> GDPSUtils::findServer(std::string url, std::string saveDir) {
-    for (auto &[id, server] : GDPSMain::get()->m_servers) {
-        if (server->url == url && server->saveDir == saveDir) {
-            return Ok(*server.get());
-        }
+    if (it->second->addedByModId != mod->getID()) {
+        return Err("Server not owned by this mod");
     }
-    return Err("Server not found");
-}
-
-// This should be a Result<void> but too late to change it.
-Result<bool> GDPSUtils::deleteServer(int id) {
     auto res = GDPSMain::get()->deleteServer(id);
     if (!res) {
         return Err(res.unwrapErr());
     }
     return Ok(true);
 }
-
-Result<bool> GDPSUtils::switchServer(int id) {
-    auto res = GDPSMain::get()->switchServer(id);
-    if (!res) {
-        return Err(res.unwrapErr());
-    }
-    return Ok(true);
-}
-
-Result<GDPSTypes::Server> GDPSUtils::getServerInfo(int id) {
-    auto it = GDPSMain::get()->m_servers.find(id);
-    if (it == GDPSMain::get()->m_servers.end()) {
-        return Err("Server not found");
-    }
-    return Ok(*it->second.get());
-}
-
-Result<bool> GDPSUtils::setServerInfo(int id, std::string name, std::string url, std::string saveDir) {
-    auto res = GDPSMain::get()->setServerInfo(id, name, url, saveDir);
-    if (!res) {
-        return Err(res.unwrapErr());
-    }
-    return Ok(true);
-}
-
-#endif

--- a/src/apis/GDPSUtils.cpp
+++ b/src/apis/GDPSUtils.cpp
@@ -1,6 +1,7 @@
 
 // MUST be defined before including the header.
 #include "../utils/GDPSMain.hpp"
+#include "Types.hpp"
 
 // Dispatch.hpp is #pragma once, so we must manually redefine
 // the macros to the "define" (export) variants here.
@@ -14,33 +15,45 @@
 #include <GDPSUtils.hpp>
 using namespace geode::prelude;
 
-Result<int> GDPSUtils::createServer(std::string name, std::string url, bool modRequired, std::string saveDir, geode::Mod* mod) {
+Result<int> GDPSUtils::createServer(CreateServerArgs args) {
     int id = 0;
     for (auto &[serverId, server] : GDPSMain::get()->m_servers) {
         if (serverId < 0) continue;
-        if (server->url == url) {
-            return Err("Server already saved as {}", name);
+        if (server->url == args.url) {
+            return Err("Server already saved as {}", args.name);
         }
         if (serverId == id) id++;
         else break;
     }
     auto server = GDPSTypes::Server();
-    server.name = name;
-    server.url = url;
+    server.name = args.name;
+    server.url = args.url;
     server.id = id;
-    server.saveDir = saveDir.empty() ? fmt::format("{}", id) : saveDir;
-    server.addedByModId = mod->getID();
-    server.modRequired = modRequired;
+    server.saveDir = args.saveDir;
+    server.motd = args.motd;
+    server.modInfo.emplace(args.mod->getID(), args.modRequired, args.customData);
     auto res = GDPSMain::get()->registerServer(std::make_shared<GDPSTypes::Server>(std::move(server)));
     if (!res) return Err(res.unwrapErr());
     GDPSMain::get()->save();
     return Ok(id);
 }
 
+Result<> GDPSUtils::updateServer(UpdateServerArgs args) {
+    GDPSTypes::Server server;
+    server.id = args.id;
+    server.name = args.name;
+    server.url = args.url;
+    server.saveDir = args.saveDir;
+    server.motd = args.motd;
+    server.modInfo.emplace(args.mod->getID(), args.modRequired, args.customData);
+    return GDPSMain::get()->modifyRegisteredServer(server);
+}
+
+
 Result<std::map<int, GDPSTypes::Server>> GDPSUtils::getModServers(geode::Mod* mod) {
     std::map<int, GDPSTypes::Server> ret;
     for (auto [id, server] : GDPSMain::get()->m_servers) {
-        if (server->addedByModId != mod->getID()) continue;
+        if (!server->modInfo.has_value() || server->modInfo->modId != mod->getID()) continue;
         ret[id] = *server.get();
     }
     return Ok(ret);
@@ -59,7 +72,7 @@ Result<bool> GDPSUtils::deleteServer(int id, geode::Mod* mod) {
     if (it == GDPSMain::get()->m_servers.end()) {
         return Err("Server not found");
     }
-    if (it->second->addedByModId != mod->getID()) {
+    if (!it->second->modInfo.has_value() || it->second->modInfo->modId != mod->getID()) {
         return Err("Server not owned by this mod");
     }
     auto res = GDPSMain::get()->deleteServer(id);

--- a/src/hooks/MenuLayer.cpp
+++ b/src/hooks/MenuLayer.cpp
@@ -1,13 +1,58 @@
 #include <Geode/Geode.hpp>
 #include <Geode/modify/MenuLayer.hpp>
 #include "../ui/ServerListLayer.hpp"
+#include "Geode/ui/Popup.hpp"
+#include "Geode/utils/general.hpp"
 #include "ui/ColorLabel.hpp"
+#include "utils/GDPSMain.hpp"
+#include <Geode/ui/PopupManager.hpp>
+#include <Types.hpp>
 
 using namespace geode::prelude;
 
 class $modify(GDPSML, MenuLayer) {
 	bool init() {
 		if (!MenuLayer::init()) return false;
+
+		//crash here is good cuz yeah
+		auto currentServer = GDPSMain::get()->getCurrentServer().unwrap(); 
+		log::info("Current server: {} ({})", currentServer->name, currentServer->id);
+		auto s = matjson::Serialize<GDPSTypes::Server>().toJson(*currentServer.get());
+		log::info("Current server json: {}", s.dump(4));
+
+
+    	if(currentServer->modInfo.has_value() && currentServer->modInfo->modRequired && !Loader::get()->getLoadedMod(currentServer->modInfo->modId)) {
+			auto& modId = currentServer->modInfo->modId;
+			auto installed = Loader::get()->getInstalledMod(modId);
+			if(installed) {
+				log::error("The mod {} is required to use the GDPS '{}'. The GDPS will not load.", modId, currentServer->name);
+				PopupManager::get().manage(
+				geode::createQuickPopup("Missing mod for GDPS",
+					fmt::format("The mod {} is required to use the GDPS '{}'. It will be enabled for you on restart.", modId, currentServer->name),
+					"Restart", nullptr, [installed](auto, bool enable) {
+							installed->enable();
+							geode::utils::game::restart(true);
+						}
+				)).showQueue();
+    		}
+
+			else {
+				log::error("The mod {} is required to use the GDPS '{}', but it is not installed. The GDPS will not load.", modId, currentServer->name);
+				Mod::get()->setSavedValue("current", ServerID::RobTop);
+				PopupManager::get().manage(
+				geode::createQuickPopup("Missing mod for GDPS",
+					fmt::format("The mod {} is required to use the GDPS '{}'. Robtop servers will load on the next startup unless you choose a different GDPS", modId, currentServer->name),
+					"Choose GDPS", "Quit Game", [](auto, bool quitgame) {
+						if(quitgame) {
+							geode::utils::game::restart(true);
+						} else {
+							cocos2d::CCDirector::get()->pushScene(ServerListLayer::scene());
+						}
+					}
+				)).showQueue();
+			}
+		}
+		
 		if (auto menu = this->getChildByID("bottom-menu")) {
 			auto spr = CircleButtonSprite::createWithSpriteFrameName(
                 		"switchServer.png"_spr,

--- a/src/ui/ServerListLayer.cpp
+++ b/src/ui/ServerListLayer.cpp
@@ -253,7 +253,7 @@ void ServerListLayer::onAdd(CCObject *sender) {
         if (serverId == id) id++;
         else break;
     }
-    ModifyServerPopup::create({id, "", "", ""}, this)->show();
+    ModifyServerPopup::create({id, "", "", "", "", false}, this)->show();
 }
 
 void ServerListLayer::onEdit(CCObject *sender) {

--- a/src/ui/ServerListLayer.cpp
+++ b/src/ui/ServerListLayer.cpp
@@ -253,7 +253,7 @@ void ServerListLayer::onAdd(CCObject *sender) {
         if (serverId == id) id++;
         else break;
     }
-    ModifyServerPopup::create({id, "", "", "", "", false}, this)->show();
+    ModifyServerPopup::create({id, "", "", ""}, this)->show();
 }
 
 void ServerListLayer::onEdit(CCObject *sender) {

--- a/src/ui/ServerNode.cpp
+++ b/src/ui/ServerNode.cpp
@@ -56,6 +56,26 @@ bool ServerNode::init(CCSize size, ServerListLayer* list, int index, GDPSTypes::
     nameLab->setAnchorPoint({0.f, 0.f});
     this->addChildAtPosition(nameLab, Anchor::TopLeft, {60, -nameLab->getContentHeight()/2 - 8});
 
+    if(!m_server->addedByModId.empty()) {
+        std::string label;
+        auto modReqLab = CCLabelBMFont::create("", "bigFont.fnt");
+
+        if(auto mod = Loader::get()->getLoadedMod(m_server->addedByModId)) {
+            label = fmt::format("GDPS {} by {}", m_server->modRequired ? "Managed" : "Added", mod->getName());
+        } else if(m_server->modRequired) {
+            label = fmt::format("GDPS Managed by {} (Mod not loaded!)", m_server->addedByModId);
+            modReqLab->setColor({ 255, 104, 104 });
+        }
+        else {
+            label = fmt::format("GDPS Added by {}", m_server->addedByModId);
+        }
+        modReqLab->setString(label.c_str(), true);
+        modReqLab->setID("mod-required");
+        modReqLab->limitLabelWidth(size.width - 150, .6f, 0.f);
+        modReqLab->setAnchorPoint({0.f, 0.f});
+        this->addChildAtPosition(modReqLab, Anchor::BottomLeft, {60, modReqLab->getContentHeight()/2 + 8});
+    }
+
     updateInfo();
 
     m_editMenu = CCMenu::create();
@@ -93,12 +113,17 @@ bool ServerNode::init(CCSize size, ServerListLayer* list, int index, GDPSTypes::
     auto pencilSpr = CCSprite::createWithSpriteFrameName("edit.png"_spr);
     pencilSpr->setScale(1.3f);
     editSpr->addChildAtPosition(pencilSpr, Anchor::Center);
-    auto editBtn = CCMenuItemSpriteExtra::create(
-        editSpr,
-        this,
-        menu_selector(ServerNode::onEdit)
-    );
-    editBtn->setID("edit-btn");
+
+    if(!m_server->addedByModId.empty()) {
+        auto editBtn = CCMenuItemSpriteExtra::create(
+            editSpr,
+            this,
+            menu_selector(ServerNode::onEdit)
+        );
+        editBtn->setID("edit-btn");
+        m_editMenu->addChild(editBtn);
+    }
+
 
     auto deleteSpr = CCSprite::create("GJ_button_06.png");
     deleteSpr->setScale(.5475f);
@@ -143,7 +168,6 @@ bool ServerNode::init(CCSize size, ServerListLayer* list, int index, GDPSTypes::
     );
     downBtn->setID("down-btn");
 
-    m_editMenu->addChild(editBtn);
     m_editMenu->addChild(upBtn);
     m_editMenu->addChild(deleteBtn);
     m_editMenu->addChild(downBtn);

--- a/src/ui/ServerNode.cpp
+++ b/src/ui/ServerNode.cpp
@@ -73,7 +73,7 @@ bool ServerNode::init(CCSize size, ServerListLayer* list, int index, GDPSTypes::
         modReqLab->setID("mod-required");
         modReqLab->limitLabelWidth(size.width - 150, .6f, 0.f);
         modReqLab->setAnchorPoint({0.f, 0.f});
-        this->addChildAtPosition(modReqLab, Anchor::BottomLeft, {60, modReqLab->getContentHeight()/2 + 8});
+        this->addChildAtPosition(modReqLab, Anchor::BottomLeft, {60, modReqLab->getContentHeight() / 2});
     }
 
     updateInfo();

--- a/src/ui/ServerNode.cpp
+++ b/src/ui/ServerNode.cpp
@@ -56,18 +56,18 @@ bool ServerNode::init(CCSize size, ServerListLayer* list, int index, GDPSTypes::
     nameLab->setAnchorPoint({0.f, 0.f});
     this->addChildAtPosition(nameLab, Anchor::TopLeft, {60, -nameLab->getContentHeight()/2 - 8});
 
-    if(!m_server->addedByModId.empty()) {
+    if(m_server->modInfo.has_value() && !m_server->modInfo->modId.empty()) {
         std::string label;
-        auto modReqLab = CCLabelBMFont::create("", "bigFont.fnt");
+        auto modReqLab = CCLabelBMFont::create("", "chatFont.fnt");
 
-        if(auto mod = Loader::get()->getLoadedMod(m_server->addedByModId)) {
-            label = fmt::format("GDPS {} by {}", m_server->modRequired ? "Managed" : "Added", mod->getName());
-        } else if(m_server->modRequired) {
-            label = fmt::format("GDPS Managed by {} (Mod not loaded!)", m_server->addedByModId);
+        if(auto mod = Loader::get()->getLoadedMod(m_server->modInfo->modId)) {
+            label = fmt::format("GDPS {} by {}", m_server->modInfo->modRequired ? "Managed" : "Added", mod->getName());
+        } else if(m_server->modInfo->modRequired) {
+            label = fmt::format("GDPS Managed by {} (Mod not loaded!)", m_server->modInfo->modId);
             modReqLab->setColor({ 255, 104, 104 });
         }
         else {
-            label = fmt::format("GDPS Added by {}", m_server->addedByModId);
+            label = fmt::format("GDPS Added by {}", m_server->modInfo->modId);
         }
         modReqLab->setString(label.c_str(), true);
         modReqLab->setID("mod-required");
@@ -114,7 +114,7 @@ bool ServerNode::init(CCSize size, ServerListLayer* list, int index, GDPSTypes::
     pencilSpr->setScale(1.3f);
     editSpr->addChildAtPosition(pencilSpr, Anchor::Center);
 
-    if(!m_server->addedByModId.empty()) {
+    if(!m_server->modInfo.has_value()) {
         auto editBtn = CCMenuItemSpriteExtra::create(
             editSpr,
             this,

--- a/src/utils/GDPSMain.cpp
+++ b/src/utils/GDPSMain.cpp
@@ -97,41 +97,6 @@ geode::Result<std::shared_ptr<GDPSTypes::Server>> GDPSMain::getServer(int id) {
     return geode::Ok(m_servers[id]);
 }
 
-geode::Result<> GDPSMain::setServerInfo(int id, std::string_view name, std::string_view url, std::string_view saveDir) {
-    auto it = m_servers.find(id);
-    if (it == m_servers.end()) {
-        return geode::Err("Server not found.");
-    }
-
-    bool shouldRestore = m_shouldSaveGameData;
-    m_shouldSaveGameData = false;
-    auto& server = it->second;
-
-    auto res = setServerSaveDir(server, saveDir); // This function handles empty strings for us.
-    if (!res) {
-        return geode::Err(res.unwrapErr());
-    }
-
-    if (!name.empty()) {
-        server->name = name;
-    }
-
-    if (!url.empty()) {
-        server->url = url;
-    }
-
-    if (m_currentServer == id) {
-        ServerAPIEvents::updateServer(m_serverApiId, server->url);
-        GSGManager::updateFileNames();
-    }
-
-    server->infoLoaded = false; // To force the fetch to work after we change the URL.
-    ServerInfoManager::get()->fetch(server);
-    m_shouldSaveGameData = shouldRestore;
-    this->save();
-    return geode::Ok();
-}
-
 geode::Result<> GDPSMain::registerServer(std::shared_ptr<GDPSTypes::Server> server) {
     if (m_servers.contains(server->id)) {
         return geode::Err("Server registery already contains this ID.\nContact developers for help.");
@@ -146,17 +111,17 @@ geode::Result<> GDPSMain::registerServer(std::shared_ptr<GDPSTypes::Server> serv
     return geode::Ok();
 }
 
-geode::Result<> GDPSMain::modifyRegisteredServer(const GDPSTypes::Server& server) {
-    if (!m_servers.contains(server.id)) {
+geode::Result<> GDPSMain::modifyRegisteredServer(const GDPSTypes::Server& newServerData) {
+    if (!m_servers.contains(newServerData.id)) {
         return geode::Err("Server with this ID does not exist.\nContact developers for help.");
     }
     
-    auto newSaveDir = server.saveDir;
-    if (server.saveDir.empty()) {
-        newSaveDir = fmt::format("{}", server.id);
+    auto newSaveDir = newServerData.saveDir;
+    if (newServerData.saveDir.empty()) {
+        newSaveDir = fmt::format("{}", newServerData.id);
     }
 
-    if (newSaveDir != m_servers[server.id]->saveDir) {
+    if (newSaveDir != m_servers[newServerData.id]->saveDir) {
         auto path = geode::dirs::getSaveDir() / "gdpses" / newSaveDir;
         std::error_code errCode;
         bool exists = std::filesystem::exists(path, errCode);
@@ -168,27 +133,29 @@ geode::Result<> GDPSMain::modifyRegisteredServer(const GDPSTypes::Server& server
 	        return geode::Err("Error checking validity of save directory: {}", errCode.message());
         }
 
-	    log::info("{}", geode::dirs::getSaveDir() / "gdpses" / m_servers[server.id]->saveDir);
+	    log::info("{}", geode::dirs::getSaveDir() / "gdpses" / m_servers[newServerData.id]->saveDir);
 
-        std::filesystem::rename(geode::dirs::getSaveDir() / "gdpses" / m_servers[server.id]->saveDir, path, errCode);
+        std::filesystem::rename(geode::dirs::getSaveDir() / "gdpses" / m_servers[newServerData.id]->saveDir, path, errCode);
 	    if (errCode) {
 	        return geode::Err("Error moving save directory: {}", errCode.message());
         }
     }
 
-    bool infoLoaded = (server.url == m_servers[server.id]->url);
+    bool infoLoaded = (newServerData.url == m_servers[newServerData.id]->url);
 
-    m_servers[server.id]->name = server.name;
-    m_servers[server.id]->url = server.url;
-    m_servers[server.id]->saveDir = newSaveDir;
-    m_servers[server.id]->infoLoaded = infoLoaded;
-
-    if (m_currentServer == server.id) {
-        ServerAPIEvents::updateServer(m_serverApiId, server.url);
+    auto& server = m_servers[newServerData.id];
+    server->name = newServerData.name;
+    server->url = newServerData.url;
+    server->saveDir = newSaveDir;
+    server->infoLoaded = infoLoaded;
+    server->modInfo = newServerData.modInfo;
+    
+    if (m_currentServer == newServerData.id) {
+        ServerAPIEvents::updateServer(m_serverApiId, newServerData.url);
         GSGManager::updateFileNames();
     }
 
-    ServerInfoManager::get()->fetch(m_servers[server.id]);
+    ServerInfoManager::get()->fetch(m_servers[newServerData.id]);
     return geode::Ok();
 }
 
@@ -250,14 +217,6 @@ geode::Result<> GDPSMain::deleteServer(int id) {
     return deleteServer(it->second);
 }
 
-geode::Result<> GDPSMain::switchServer(int id) {
-    if (!serverExists(id)) {
-        return geode::Err("Server does not exist!");
-    }
-
-    m_currentServer = id;
-    return geode::Ok();
-}
 
 GDPSTypes::ServerInvalidity GDPSMain::isValidServer(const GDPSTypes::Server& server) const {
     using namespace GDPSTypes;
@@ -295,7 +254,7 @@ void GDPSMain::init() {
     // ReSharper disable once CppDFAArrayIndexOutOfBounds
     m_servers[-2] = std::make_shared<GDPSTypes::Server>(base);
     auto* server = m_servers[m_currentServer].get();
-    if(server->modRequired && !Loader::get()->getLoadedMod(server->addedByModId)) {
+    if(server->modInfo.has_value() && server->modInfo->modRequired && !Loader::get()->getLoadedMod(server->modInfo->modId)) {
         m_currentServer = ServerID::RobTop;
         server = m_servers[m_currentServer].get();
     }

--- a/src/utils/GDPSMain.cpp
+++ b/src/utils/GDPSMain.cpp
@@ -288,13 +288,18 @@ void GDPSMain::init() {
     m_currentServer =
         Mod::get()->getSavedValue<int>("current", -2);
 
-    auto base = GDPSTypes::Server{-2, "Built-in Servers", ServerAPIEvents::getBaseUrl(), ".."};
+    auto base = GDPSTypes::Server{-2, "Built-in Servers", ServerAPIEvents::getBaseUrl(), "..", "", false};
     base.iconIsSprite = true;
     base.icon = "gdlogo.png"_spr;
     base.motd = "Vanilla Geometry Dash servers.";
     // ReSharper disable once CppDFAArrayIndexOutOfBounds
     m_servers[-2] = std::make_shared<GDPSTypes::Server>(base);
-    const auto &server = m_servers[m_currentServer];
+    auto* server = m_servers[m_currentServer].get();
+    if(server->modRequired && !Loader::get()->getLoadedMod(server->addedByModId)) {
+        m_currentServer = ServerID::RobTop;
+        server = m_servers[m_currentServer].get();
+    }
+
     if (m_currentServer >= 0 && isActive()) {
         log::info("Loading into GDPS: {}", server->url);
         m_serverApiId = ServerAPIEvents::registerServer(server->url, -40).id;

--- a/src/utils/GDPSMain.cpp
+++ b/src/utils/GDPSMain.cpp
@@ -92,7 +92,7 @@ geode::Result<std::shared_ptr<GDPSTypes::Server>> GDPSMain::getCurrentServer() {
 
 geode::Result<std::shared_ptr<GDPSTypes::Server>> GDPSMain::getServer(int id) {
     if (!m_servers.contains(id)) {
-        return geode::Err("Server at {} not found");
+        return geode::Err(fmt::format("Server at {} not found", id));
     }
     return geode::Ok(m_servers[id]);
 }
@@ -180,26 +180,23 @@ geode::Result<> GDPSMain::deleteServer(std::shared_ptr<GDPSTypes::Server> server
     std::filesystem::path canonicalServerPath;
     canonicalServerPath.clear();
     canonicalServerPath = std::filesystem::canonical(serverPath, err);
-    if (err) {
-        return geode::Err("Failed to get canonical path for {}: {}", serverPath, err.message());
-    }
 
-    if (
-        !geode::utils::string::pathToString(canonicalServerPath).starts_with(geode::utils::string::pathToString(gdpsesDir))
-        || serverPath == gdpsesDir
-    ) {
-        return geode::Err(
-            "Attempted to delete a path outside or equal to the gdpses directory: {}\n\n"
-            "To prevent unintentional extra data loss, your save was not deleted - "
-            "only saves within {} will be deleted. If you want to delete this data, do it manually.",
-            serverPath, gdpsesDir
-        );
-    }
+        if (
+            !geode::utils::string::pathToString(canonicalServerPath).starts_with(geode::utils::string::pathToString(gdpsesDir))
+            || serverPath == gdpsesDir
+        ) {
+            return geode::Err(
+                "Attempted to delete a path outside or equal to the gdpses directory: {}\n\n"
+                "To prevent unintentional extra data loss, your save was not deleted - "
+                "only saves within {} will be deleted. If you want to delete this data, do it manually.",
+                serverPath, gdpsesDir
+            );
+        }
 
-    log::debug("Deleting {}", serverPath);
-    std::filesystem::remove_all(serverPath, err);
-    if (err) {
-        return geode::Err("Failed to delete save data for {}: {}", server->name, err.message());
+        log::debug("Deleting {}", serverPath);
+        std::filesystem::remove_all(serverPath, err);
+        if (err) {
+            return geode::Err("Failed to delete save data for {}: {}", server->name, err.message());
     }
 
     m_servers.erase(server->id);
@@ -247,18 +244,13 @@ void GDPSMain::init() {
     m_currentServer =
         Mod::get()->getSavedValue<int>("current", -2);
 
-    auto base = GDPSTypes::Server{-2, "Built-in Servers", ServerAPIEvents::getBaseUrl(), "..", "", false};
+    auto base = GDPSTypes::Server{-2, "Built-in Servers", ServerAPIEvents::getBaseUrl(), ".."};
     base.iconIsSprite = true;
     base.icon = "gdlogo.png"_spr;
     base.motd = "Vanilla Geometry Dash servers.";
     // ReSharper disable once CppDFAArrayIndexOutOfBounds
     m_servers[-2] = std::make_shared<GDPSTypes::Server>(base);
     auto* server = m_servers[m_currentServer].get();
-    if(server->modInfo.has_value() && server->modInfo->modRequired && !Loader::get()->getLoadedMod(server->modInfo->modId)) {
-        m_currentServer = ServerID::RobTop;
-        server = m_servers[m_currentServer].get();
-    }
-
     if (m_currentServer >= 0 && isActive()) {
         log::info("Loading into GDPS: {}", server->url);
         m_serverApiId = ServerAPIEvents::registerServer(server->url, -40).id;


### PR DESCRIPTION
The API is similar to the old one but with the main difference being that it keeps track of which mods added whiuch gdpses. This is for safety, as one mod should only tinker with the GDPS it added and not anything else. 

For developers of gdpses that mostly follow vanilla and don't change the game a lot (eg only add some extra features or changes, but the GDPS works fine in vanilla)
For this case developers should use `GDPSUtils::createServer` and leave `modRequired` as `false`. This will allow the gdps to work without the mod being loaded.

For developers of gdpses that can not work without the mod (heavy modifications). In this case developers should use  `GDPSUtils::createServer` and set `modRequired` as `true`.  This will display a message on menu init if the necessary mod is not loaded. 

For GDPS hosting services such as GDPSFH and similar, everything is already covered with the previous cases but a custom data has to be stored alongside each GDPS for cases when a GDPS changes its server-side properties (name, desc, even url or anything else). For this a `customData` general member was added in the struct `Server::ModInfo`

Below are a few screenshots of me using the API with a custom mod (not gdpsfh)
Successful load and registering:
<img width="1285" height="796" alt="{80066607-6591-491A-A629-320126685DCA}" src="https://github.com/user-attachments/assets/59a01cb3-7d19-4c36-9748-8ed95c0bd4bd" />

Disabling `gdps-mod` and restarting:
<img width="1275" height="780" alt="{583309EE-744E-4458-B2DE-DB4E38602464}" src="https://github.com/user-attachments/assets/7591469a-b2fb-4cb5-9186-c41df7e5837c" />


Uninstalling the mod instead:
<img width="1281" height="787" alt="{201A9B1F-DE2F-4517-A392-D91B9B6EAC85}" src="https://github.com/user-attachments/assets/4df30bca-f441-437a-9467-818d207be494" />

The PR is not finished but I open it so direction & design can be discussed. If that passed, some TODOS:
- api docs in header
- disable "use" button if gdps is not accessible because the mod is not loaded
- since the edit button is gone on mod-added gdpses, the edit mode button placement is a bit goofy